### PR TITLE
Fix news pipeline: ORCID author search + mktemp

### DIFF
--- a/scripts/fetch-news.py
+++ b/scripts/fetch-news.py
@@ -82,16 +82,17 @@ def fetch_xml(url):
 
 
 # ---------------------------------------------------------------------------
-# Source: CrossRef (publications by author)
+# Source: CrossRef (publications by author ORCID)
 # ---------------------------------------------------------------------------
 def search_crossref(authors, since_date):
-    """Search CrossRef for recent publications by authors."""
+    """Search CrossRef for recent publications by author ORCID."""
     candidates = []
     for author in authors:
-        print(f"  CrossRef: searching for '{author}'...", file=sys.stderr)
+        name = author["name"]
+        orcid = author["orcid"]
+        print(f"  CrossRef: searching ORCID {orcid} ({name})...", file=sys.stderr)
         query = urllib.parse.urlencode({
-            "query.author": author,
-            "filter": f"from-pub-date:{since_date}",
+            "filter": f"orcid:{orcid},from-pub-date:{since_date}",
             "rows": 10,
             "sort": "published",
             "order": "desc",
@@ -119,22 +120,29 @@ def search_crossref(authors, since_date):
                 "date": date_str,
                 "link": link,
                 "source": "CrossRef",
+                "mf_author": name,
                 "raw_abstract": item.get("abstract", ""),
             })
     return candidates
 
 
 # ---------------------------------------------------------------------------
-# Source: OpenAlex (publications by author name)
+# Source: OpenAlex (publications by author ORCID)
 # ---------------------------------------------------------------------------
 def search_openalex(authors, since_date):
-    """Search OpenAlex for recent publications by authors."""
+    """Search OpenAlex for recent publications by author ORCID."""
     candidates = []
     for author in authors:
-        print(f"  OpenAlex: searching for '{author}'...", file=sys.stderr)
-        safe_author = urllib.parse.quote(author)
-        query = f"filter=authorships.author.display_name.search:{safe_author},from_publication_date:{since_date}&sort=publication_date:desc&per-page=10&mailto=info@mountainfutures.ch"
-        url = f"https://api.openalex.org/works?{query}"
+        name = author["name"]
+        orcid = author["orcid"]
+        print(f"  OpenAlex: searching ORCID {orcid} ({name})...", file=sys.stderr)
+        orcid_filter = urllib.parse.quote(f"https://orcid.org/{orcid}", safe="")
+        url = (
+            "https://api.openalex.org/works"
+            f"?filter=authorships.author.orcid:{orcid_filter},from_publication_date:{since_date}"
+            "&sort=publication_date:desc&per-page=10"
+            "&mailto=info@mountainfutures.ch"
+        )
         data = fetch_json(url)
         if not data:
             continue
@@ -150,6 +158,7 @@ def search_openalex(authors, since_date):
                 "date": item.get("publication_date", since_date),
                 "link": link,
                 "source": "OpenAlex",
+                "mf_author": name,
                 "raw_abstract": (item.get("abstract_inverted_index") or "")
                     if isinstance(item.get("abstract_inverted_index"), str)
                     else "",

--- a/scripts/glossary.json
+++ b/scripts/glossary.json
@@ -1,7 +1,7 @@
 {
   "authors": [
-    "Joel Fiddes",
-    "Simon Allen"
+    {"name": "Joel Fiddes", "orcid": "0000-0003-2870-6972"},
+    {"name": "Simon Allen", "orcid": "0000-0002-4809-649X"}
   ],
   "search_terms": [
     "Mountain Futures Switzerland",

--- a/scripts/update-news.sh
+++ b/scripts/update-news.sh
@@ -16,11 +16,13 @@ unset CLAUDECODE 2>/dev/null || true
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_DIR"
 
-CANDIDATES_FILE=$(mktemp /tmp/news-candidates.XXXXX.json)
-FILTERED_FILE=$(mktemp /tmp/news-filtered.XXXXX.json)
+# Note: macOS BSD mktemp only randomizes trailing X's — no suffix after them.
+CANDIDATES_FILE=$(mktemp /tmp/news-candidates.XXXXXX)
+FILTERED_FILE=$(mktemp /tmp/news-filtered.XXXXXX)
+PROMPT_FILE=""
 NEWS_JSON="$REPO_DIR/src/data/news.json"
 
-cleanup() { rm -f "$CANDIDATES_FILE" "$FILTERED_FILE"; }
+cleanup() { rm -f "$CANDIDATES_FILE" "$FILTERED_FILE" ${PROMPT_FILE:+"$PROMPT_FILE"}; }
 trap cleanup EXIT
 
 echo "=== Step 1: Fetching candidates ==="
@@ -38,7 +40,7 @@ echo ""
 echo "=== Step 2: Claude Code filtering and post generation ==="
 
 # Build prompt file (avoids shell escaping issues with large JSON)
-PROMPT_FILE=$(mktemp /tmp/news-prompt.XXXXX.txt)
+PROMPT_FILE=$(mktemp /tmp/news-prompt.XXXXXX)
 cat > "$PROMPT_FILE" <<PROMPT
 You are curating a news feed for Mountain Futures (mountainfutures.ch), a Swiss
 consultancy by Joel Fiddes and Simon Allen focused on cryosphere science, mountain
@@ -58,8 +60,14 @@ INSTRUCTIONS:
 1. STRICTLY filter: only include items directly about Mountain Futures' work, their
    named people (Joel Fiddes, Simon Allen — the cryosphere researchers, not other
    people with the same name), or their specific projects/topics.
-2. REJECT generic climate/mountain news and papers by unrelated authors.
-3. For accepted items, write a clean 1-2 sentence summary.
+2. Items with an "mf_author" field are ORCID-verified to be authored by that MF
+   team member — ACCEPT these by default unless the title is clearly off-topic
+   (e.g. unrelated domain like marine biology or pathogens, which can occur due
+   to OpenAlex author-merging errors).
+3. REJECT generic climate/mountain news and papers by unrelated authors when
+   "mf_author" is not present.
+4. For accepted items, write a clean 1-2 sentence summary. Mention the MF author
+   by name in the summary when "mf_author" is set.
 
 CRITICAL: When in doubt, EXCLUDE. Do NOT fabricate information.
 


### PR DESCRIPTION
## Summary
- **CrossRef + OpenAlex**: switch from name-string search (matched homonyms — credit-card papers, a volleyball book) to **ORCID-filtered** queries for Joel Fiddes (`0000-0003-2870-6972`) and Simon Allen (`0000-0002-4809-649X`).
- **Resolved author** is carried as `mf_author` on each candidate so Claude's filter can trust the attribution and stop excluding genuine MF papers as "could be a different author".
- **`mktemp` fix**: macOS BSD `mktemp` only randomizes *trailing* X's. The `.txt`/`.json` suffix after the X's caused literal filenames, and a leaked `/tmp/news-prompt.XXXXX.txt` from a prior crash blocked every cron run since March. Dropped suffixes and added `PROMPT_FILE` to the cleanup trap.

## Effect
Verified end-to-end. Before this fix, 30-day searches surfaced 50 candidates of which **0** were on-topic. After: 33 candidates, of which **2 ORCID-verified author papers** were accepted by Claude and merged via PR #2:
- *Record-breaking glacier mass loss in Central Asia in 2025* (Joel)
- *Advancing stakeholder engagement in climate adaptation* (Simon)

## Test plan
- [x] Author search returns only ORCID-matched works (verified manually for both ORCIDs)
- [x] `mktemp` produces unique paths (`/tmp/news-prompt.WZ4xkg` etc.)
- [x] Full pipeline run produces a clean PR with correct items
- [ ] Next 9am cron run completes without leaking tempfiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)